### PR TITLE
Refactor error handling in get_transaction_status

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "*"
+      - "**"
     tags:
       - "v*"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository  }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64
+          file: ./Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PATHFINDER_FORCE_VERSION=v0.14.1-cartridge
+          cache-from: type=gha
+          cache-to: type=gha,mode=max`
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,8 +930,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.8.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb87d3c5d71fe593c120cd73036d3982986596942e3c1a5dc81e2661f397cf4"
+source = "git+https://github.com/cartridge-gg/blockifier?branch=nonce-check-flag#442ac12942deff3a4ea9a7d71bf4fe1f71292447"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -954,6 +953,7 @@ dependencies = [
  "num-rational",
  "num-traits 0.2.19",
  "once_cell",
+ "paste",
  "phf",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ axum = "0.7.5"
 base64 = "0.13.1"
 bincode = "2.0.0-rc.3"
 bitvec = "1.0.1"
-blockifier = "=0.8.0-rc.1"
+blockifier = { git = "https://github.com/cartridge-gg/blockifier", branch = "nonce-check-flag" }
 bloomfilter = "1.0.12"
 bytes = "1.4.0"
 cached = "0.44.0"

--- a/crates/executor/src/estimate.rs
+++ b/crates/executor/src/estimate.rs
@@ -9,6 +9,7 @@ pub fn estimate(
     execution_state: ExecutionState<'_>,
     transactions: Vec<Transaction>,
     skip_validate: bool,
+    skip_nonce_check: bool,
 ) -> Result<Vec<FeeEstimate>, TransactionExecutionError> {
     let block_number = execution_state.header.number;
 
@@ -32,7 +33,13 @@ pub fn estimate(
         let tx_info: Result<
             blockifier::transaction::objects::TransactionExecutionInfo,
             blockifier::transaction::errors::TransactionExecutionError,
-        > = transaction.execute(&mut state, &block_context, false, !skip_validate);
+        > = transaction.execute(
+            &mut state,
+            &block_context,
+            false,
+            !skip_validate,
+            !skip_nonce_check,
+        );
 
         match tx_info {
             Ok(tx_info) => {

--- a/crates/executor/src/simulate.rs
+++ b/crates/executor/src/simulate.rs
@@ -108,6 +108,7 @@ pub fn simulate(
             &block_context,
             !skip_fee_charge,
             !skip_validate,
+            true,
         );
         let state_diff = to_state_diff(&mut tx_state, transaction_declared_deprecated_class_hash)?;
         tx_state.commit();
@@ -185,7 +186,7 @@ pub fn trace(
 
         let mut tx_state = CachedState::<_>::create_transactional(&mut state);
         let tx_info = tx
-            .execute(&mut tx_state, &block_context, true, true)
+            .execute(&mut tx_state, &block_context, true, true, true)
             .map_err(|e| {
                 // Update the cache with the error. Lock the cache before sending to avoid
                 // race conditions between senders and receivers.

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -21,7 +21,7 @@ pub enum Output {
 pub enum Error {
     Internal(anyhow::Error),
     TxnHashNotFound,
-    GatewayError(starknet_gateway_types::error::StarknetError),
+    GatewayIssue(starknet_gateway_types::error::StarknetError),
 }
 
 impl From<anyhow::Error> for Error {
@@ -35,7 +35,7 @@ impl From<starknet_gateway_types::error::SequencerError> for Error {
         use starknet_gateway_types::error::SequencerError::*;
 
         match e {
-            StarknetError(e) => Error::GatewayError(e),
+            StarknetError(e) => Error::GatewayIssue(e),
             ReqwestError(e) => Error::Internal(e.into()),
             InvalidStarknetErrorVariant => Error::Internal(anyhow::anyhow!("Invalid error variant received from gateway")),
         }
@@ -47,7 +47,7 @@ impl From<Error> for crate::error::ApplicationError {
         match e {
             Error::Internal(internal) => Self::Internal(internal),
             Error::TxnHashNotFound => Self::TxnHashNotFound,
-            Error::GatewayError(gateway_error) => Self::GatewayError(gateway_error),
+            Error::GatewayIssue(gateway_error) => Self::GatewayError(gateway_error),
         }
     }
 }

--- a/crates/rpc/src/method/get_transaction_status.rs
+++ b/crates/rpc/src/method/get_transaction_status.rs
@@ -37,7 +37,9 @@ impl From<starknet_gateway_types::error::SequencerError> for Error {
         match e {
             StarknetError(e) => Error::GatewayIssue(e),
             ReqwestError(e) => Error::Internal(e.into()),
-            InvalidStarknetErrorVariant => Error::Internal(anyhow::anyhow!("Invalid error variant received from gateway")),
+            InvalidStarknetErrorVariant => Error::Internal(anyhow::anyhow!(
+                "Invalid error variant received from gateway"
+            )),
         }
     }
 }

--- a/crates/rpc/src/v05/method/estimate_fee.rs
+++ b/crates/rpc/src/v05/method/estimate_fee.rs
@@ -142,7 +142,13 @@ pub async fn estimate_fee(
             .map(|tx| crate::executor::map_broadcasted_transaction(&tx, context.chain_id))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let result = pathfinder_executor::estimate(state, transactions, false)?;
+        let result = pathfinder_executor::estimate(
+            state,
+            transactions,
+            false,
+            // skip nonce check because it is not necessary for fee estimation
+            true,
+        )?;
 
         Ok::<_, EstimateFeeError>(result)
     })

--- a/crates/rpc/src/v06/method/estimate_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_fee.rs
@@ -192,7 +192,13 @@ pub async fn estimate_fee_impl(
             .map(|tx| crate::executor::map_broadcasted_transaction(&tx, context.chain_id))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let result = pathfinder_executor::estimate(state, transactions, skip_validate)?;
+        let result = pathfinder_executor::estimate(
+            state,
+            transactions,
+            skip_validate,
+            // skip nonce check because it is not necessary for fee estimation
+            true,
+        )?;
 
         Ok::<_, EstimateFeeError>(result)
     })

--- a/crates/rpc/src/v06/method/estimate_message_fee.rs
+++ b/crates/rpc/src/v06/method/estimate_message_fee.rs
@@ -152,7 +152,13 @@ pub(crate) async fn estimate_message_fee_impl(
 
         let transaction = create_executor_transaction(input, context.chain_id)?;
 
-        let result = pathfinder_executor::estimate(state, vec![transaction], false)?;
+        let result = pathfinder_executor::estimate(
+            state,
+            vec![transaction],
+            false,
+            // skip nonce check because it is not necessary for fee estimation
+            true,
+        )?;
 
         Ok::<_, EstimateMessageFeeError>(result)
     })

--- a/crates/rpc/src/v06/method/simulate_transactions.rs
+++ b/crates/rpc/src/v06/method/simulate_transactions.rs
@@ -903,6 +903,39 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn test_simulate_transaction_with_invalid_nonce_will_fail() {
+        let (context, _, _, _) = crate::test_setup::test_context().await;
+
+        // create transaction with invalid nonce
+        let input_json = serde_json::json!({
+            "block_id": {"block_number": 1},
+            "transactions": [
+                {
+                    "contract_address_salt": "0x46c0d4abf0192a788aca261e58d7031576f7d8ea5229f452b0f23e691dd5971",
+                    "max_fee": "0x0",
+                    "signature": [],
+                    "class_hash": DUMMY_ACCOUNT_CLASS_HASH,
+                    "nonce": "0x1337",
+                    "version": TransactionVersion::ONE_WITH_QUERY_VERSION,
+                    "constructor_calldata": [],
+                    "type": "DEPLOY_ACCOUNT"
+                }
+            ],
+            "simulation_flags": ["SKIP_FEE_CHARGE"]
+        });
+
+        // assert that the simulation returns an error due to invalid nonce
+        let input = SimulateTransactionInput::deserialize(&input_json).unwrap();
+        let err = simulate_transactions(context, input).await.unwrap_err();
+
+        if let SimulateTransactionError::TransactionExecutionError { error, .. } = err {
+            assert!(error.contains("Invalid transaction nonce"))
+        } else {
+            panic!("Unexpected error")
+        }
+    }
+
+    #[tokio::test]
     async fn declare_cairo_v0_class() {
         pub const CAIRO0_DEFINITION: &[u8] =
             include_bytes!("../../../fixtures/contracts/cairo0_test.json");


### PR DESCRIPTION
Clarified error variants by introducing an Error enum and implemented conversions from anyhow::Error and SequencerError. This enhances the readability and maintainability of the code by specifying distinct error types and their mappings.